### PR TITLE
Don't expose certificate symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,9 @@ file(READ "${certificates_bundle}" certificates_data HEX)
 
 string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," certificates_array "${certificates_data}")
 
-set(certificates "${CMAKE_CURRENT_BINARY_DIR}/certificates.c")
+set(certificates "${CMAKE_CURRENT_BINARY_DIR}/certificates.h")
 
-file(WRITE "${certificates}"
-  "#include <stddef.h>\n\n"
-  "const unsigned char bare_tls__certs[] = {\n${certificates_array}\n};\n\n"
-  "const size_t bare_tls__certs_len = sizeof(bare_tls__certs);\n"
-)
+configure_file(lib/certificates.h.in "${certificates}" @ONLY)
 
 add_bare_module(bare_tls)
 
@@ -53,4 +49,10 @@ target_link_libraries(
   ${bare_tls}
   PUBLIC
     ssl
+)
+
+target_include_directories(
+  ${bare_tls}
+  PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}"
 )

--- a/binding.c
+++ b/binding.c
@@ -11,8 +11,7 @@
 #include <openssl/x509.h>
 #include <stddef.h>
 
-extern const unsigned char bare_tls__certs[];
-extern const size_t bare_tls__certs_len;
+#include "certificates.h"
 
 typedef struct {
   SSL_CTX *ssl;

--- a/lib/certificates.h.in
+++ b/lib/certificates.h.in
@@ -1,0 +1,7 @@
+#include <stddef.h>
+
+static const unsigned char bare_tls__certs[] = {
+@certificates_array@
+};
+
+static const size_t bare_tls__certs_len = sizeof(bare_tls__certs);


### PR DESCRIPTION
It breaks the static Bare build, https://github.com/holepunchto/bare/pull/134.